### PR TITLE
Add the statitics of gen_size into MergerUnit and DelimiterInserter

### DIFF
--- a/defDataBusAbst.vhd
+++ b/defDataBusAbst.vhd
@@ -9,6 +9,7 @@ package defDataBusAbst is
 
   -- TDC Data Array ---------------------------------------------------------------------------
   type FineCountArrayType is array (natural range <>) of std_logic_vector;
+  type ChannelArrayType   is array (natural range <>) of std_logic_vector;
   type TimingArrayType    is array (natural range <>) of std_logic_vector;
   type TOTArrayType       is array (natural range <>) of std_logic_vector;
 

--- a/lrtdc-impl/defTDC.vhd
+++ b/lrtdc-impl/defTDC.vhd
@@ -18,6 +18,9 @@ package defTDC is
   -- FineCounterDecoder parameters -----------------------------------------------------
   constant kWidthFineCount  : integer  := 3;
 
+  -- Channel ---------------------------------------------------------------------------
+  constant kWidthChannel    : integer  := kPosChannel'length;
+
   -- TdcUnit ---------------------------------------------------------------------------
   constant kWidthTiming     : integer  := kPosTiming'length;
 

--- a/odpblock/DelimiterInserter.vhd
+++ b/odpblock/DelimiterInserter.vhd
@@ -9,21 +9,19 @@ use mylib.defDelimiter.all;
 
 entity DelimiterInserter is
   generic(
-    kNumInput   : integer:= 32;
     enDEBUG     : boolean:= false
   );
   port(
-    genChOffset : in std_logic;
-
     clk         : in std_logic;   -- base clock
     syncReset   : in std_logic;   -- Synchronous reset
 
     -- TDC in --
-    validIn         : in  std_logic_vector(kNumInput-1 downto 0);
-    dInTiming       : in  TimingArrayType(kNumInput-1 downto 0)(kPosTiming'length-1 downto 0);
-    isLeading       : in  std_logic_vector(kNumInput-1 downto 0);
-    isConflicted    : in  std_logic_vector(kNumInput-1 downto 0);
-    dInToT          : in  TOTArrayType(kNumInput-1 downto 0)(kPosTot'length-1 downto 0);
+    validIn         : in  std_logic;
+    dInChannel      : in  std_logic_vector(kPosChannel'length-1 downto 0);
+    dInTiming       : in  std_logic_vector(kPosTiming'length-1 downto 0);
+    isLeading       : in  std_logic;
+    isConflicted    : in  std_logic;
+    dInToT          : in  std_logic_vector(kPosTot'length-1 downto 0);
 
     -- delimiter in --
     validDelimiter  : in  std_logic;
@@ -32,25 +30,37 @@ entity DelimiterInserter is
     hbfThrottlingOn : in  std_logic;
 
     -- Pairing out --
-    validOut        : out std_logic_vector(kNumInput-1 downto 0);
-    dOut            : out DataArrayType(kNumInput-1 downto 0)
+    validOut        : out std_logic;
+    dOut            : out std_logic_vector(kWidthData-1 downto 0)
   );
 end DelimiterInserter;
 
 architecture RTL of DelimiterInserter is
   attribute mark_debug  : boolean;
 
+  -- data input
+  signal delimiter_valid      : std_logic;
+  signal delimiter_data       : std_logic_vector(kWidthData-1 downto 0);
 
-  signal channel_offset   : integer:=0;
+  signal tdc_valid            : std_logic;
+  signal tdc_data             : std_logic_vector(kWidthData-1 downto 0);
 
-  signal tdc_data_valid   : std_logic_vector(kNumInput-1 downto 0);
-  signal tdc_data         : DataArrayType(kNumInput-1 downto 0);
+  -- data merge
+  signal buff_delimiter_valid : std_logic_vector(2 downto 0)  := (others=>'0');
+  signal buff_delimiter_data  : DataArrayType(2 downto 0);
 
-  signal delimiter_valid  : std_logic;
-  signal delimiter_data   : std_logic_vector(kWidthData-1 downto 0);
+  signal buff_tdc_valid       : std_logic_vector(2 downto 0)  := (others=>'0');
+  signal buff_tdc_data        : DataArrayType(2 downto 0);
 
-  signal data_valid_out   : std_logic_vector(kNumInput-1 downto 0);
-  signal data_out         : DataArrayType(kNumInput-1 downto 0);
+  signal merge_valid          : std_logic;
+  signal merge_data           : std_logic_vector(kWidthData-1 downto 0);
+
+  -- data output
+  signal is_2nd_delimiter     : std_logic;
+  signal num_word             : unsigned(kPosHbdGenSize'length-4 downto 0);
+
+  signal data_valid_out       : std_logic;
+  signal data_out             : std_logic_vector(kWidthData-1 downto 0);
 
   -- debug ----------------------------------------------------------
 --  attribute mark_debug of delimiter_data  : signal is enDEBUG;
@@ -62,80 +72,145 @@ architecture RTL of DelimiterInserter is
 begin
   -- =========================== body ===============================
 
-  channel_offset  <= kNumInput when(genChOffset = '1') else 0;
-
+  -- data input
   delimiter_valid <= validDelimiter;
   delimiter_data  <= dInDelimiter;
 
---  u_delimiter : process(clk)
---  begin
---    if(clk'event and clk = '1') then
---      if(syncReset = '1') then
---        delimiter_valid   <= '0';
---      else
---        if(validDelimiter = '1') then
---          delimiter_valid   <= '1';
---          delimiter_data    <= dInDelimiter;
-----          if(unsigned(validIn) /= 0) then -- conflict flag
-----            delimiter_data(kIndexConflict + kLSBFlag)  <= '1';
-----          end if;
---        else
---          delimiter_valid   <= '0';
---        end if;
---      end if;
---    end if;
---  end process;
-
-  gen_ch : for i in 0 to kNumInput-1 generate
-
-    u_tdc : process(clk)
-    begin
-      if(clk'event and clk = '1') then
-        if(syncReset = '1') then
-          tdc_data_valid(i)   <= '0';
-        else
-          if(validIn(i) ='1' and hbfThrottlingOn = '0') then
-            if(isLeading(i) = '1') then
-              tdc_data(i)(kPosHbdDataType'range)  <= kDatatypeTDCData;
-            else
-              tdc_data(i)(kPosHbdDataType'range)  <= kDatatypeTDCDataT;
-            end if;
-
-            tdc_data_valid(i)                <= '1';
-            tdc_data(i)(kPosChannel'range)   <= std_logic_vector(to_unsigned(i+channel_offset, kPosChannel'length));
-            tdc_data(i)(kPosTot'range)       <= dInToT(i);
-            tdc_data(i)(kPosTiming'high downto 0) <= (kPosTiming'range => dInTiming(i), others => '0');
+  u_tdc : process(clk)
+  begin
+    if(clk'event and clk = '1') then
+      if(syncReset = '1') then
+        tdc_valid  <= '0';
+      else
+        if(validIn ='1' and hbfThrottlingOn = '0') then
+          if(isLeading = '1') then
+            tdc_data(kPosHbdDataType'range)  <= kDatatypeTDCData;
           else
-            tdc_data_valid(i) <= '0';
+            tdc_data(kPosHbdDataType'range)  <= kDatatypeTDCDataT;
           end if;
+
+          tdc_valid                           <= '1';
+          tdc_data(kPosChannel'range)         <= dInChannel;
+          tdc_data(kPosTot'range)             <= dInToT;
+          tdc_data(kPosTiming'high downto 0)  <= (kPosTiming'range => dInTiming, others => '0');
+        else
+          tdc_valid  <= '0';
         end if;
       end if;
-    end process;
-
-    u_out : process(clk)
-    begin
-      if(clk'event and clk = '1') then
-        if(syncReset = '1') then
-          data_valid_out(i) <= '0';
-        else
-          if(daqOn = '1') then
-            if(delimiter_valid = '1') then
-              data_valid_out(i) <= '1';
-              data_out(i)       <= delimiter_data;
-            elsif(tdc_data_valid(i) = '1') then
-              data_valid_out(i) <= '1';
-              data_out(i)       <= tdc_data(i);
-            else
-              data_valid_out(i) <= '0';
-            end if;
-          else
-            data_valid_out(i) <= '0';
-          end if;
+    end if;
+  end process;
+  
+  -- data merge
+  buff_delimiter : process(clk)
+  begin
+    if(clk'event and clk = '1') then
+      buff_delimiter_valid(2) <= delimiter_valid;
+      buff_delimiter_data(2)  <= delimiter_data;
+      buff_delimiter_valid(1) <= buff_delimiter_valid(2);
+      buff_delimiter_data(1)  <= buff_delimiter_data(2);
+      buff_delimiter_valid(0) <= buff_delimiter_valid(1);
+      buff_delimiter_data(0)  <= buff_delimiter_data(1);
+    end if;
+  end process;
+  
+  buff_tdc_2 : process(clk)
+  begin
+    if(clk'event and clk = '1') then
+      -- without conflict (clean buffer)
+      if(buff_delimiter_valid(0)='0')then
+        if(buff_tdc_valid(2)='1')then
+          buff_tdc_valid(2) <= tdc_valid;
+          buff_tdc_data(2)  <= tdc_data;
+        end if;
+      -- conflicted with delimiter (buff is emtyp)
+      else
+        if(buff_tdc_valid(2)='0' and buff_tdc_valid(1)='1')then
+          buff_tdc_valid(2) <= tdc_valid;
+          buff_tdc_data(2)  <= tdc_data;
         end if;
       end if;
-    end process;
+    end if;
+  end process;
+  
+  buff_tdc_1 : process(clk)
+  begin
+    if(clk'event and clk = '1') then
+      -- without conflict (clean buffer)
+      if(buff_delimiter_valid(0)='0')then
+        if(buff_tdc_valid(2)='1')then
+          buff_tdc_valid(1) <= buff_tdc_valid(2);
+          buff_tdc_data(1)  <= buff_tdc_data(2);
+        elsif(buff_tdc_valid(1)='1')then
+          buff_tdc_valid(1) <= tdc_valid;
+          buff_tdc_data(1)  <= tdc_data;
+        end if;
+      -- conflicted with delimiter (buff is emtyp)
+      else
+        if(buff_tdc_valid(1)='0' and buff_tdc_valid(0)='1')then
+          buff_tdc_valid(1) <= tdc_valid;
+          buff_tdc_data(1)  <= tdc_data;
+        end if;
+      end if;
+    end if;
+  end process;
+  
+  buff_tdc_0 : process(clk)
+  begin
+    if(clk'event and clk = '1') then
+      -- without conflict (clean buffer)
+      if(buff_delimiter_valid(0)='0')then
+        if(buff_tdc_valid(1)='1')then
+          buff_tdc_valid(0) <= buff_tdc_valid(1);
+          buff_tdc_data(0)  <= buff_tdc_data(1);
+        else
+          buff_tdc_valid(0) <= tdc_valid;
+          buff_tdc_data(0)  <= tdc_data;
+        end if;
+      -- conflicted with delimiter (buff is emtyp)
+      else
+        if(buff_tdc_valid(0)='0')then
+          buff_tdc_valid(0) <= tdc_valid;
+          buff_tdc_data(0)  <= tdc_data;
+        end if;
+      end if;
+    end if;
+  end process;
+  
+  -- data output
+  merger : process(clk)
+  begin
+    if(clk'event and clk = '1') then
+      -- reset or daq_off
+      if(syncReset = '1' or daqOn = '0') then
+        data_valid_out    <= '0';
+        is_2nd_delimiter  <= '0';
+        num_word          <= (others=>'0');
+      
+      -- delimiter
+      elsif(buff_delimiter_valid(0)='1')then
+        data_valid_out    <= '1';
+        data_out          <= buff_delimiter_data(0);
+        -- insert the gen tdc size into the 2nd delimiter word.
+        if(is_2nd_delimiter='1')then
+          data_out(kPosHbdGenSize'range) <= std_logic_vector(num_word) & "000";
+          is_2nd_delimiter  <= '0';
+          num_word          <= (others=>'0');
+        else
+          is_2nd_delimiter  <= '1';
+        end if;
+      
+      -- tdc data
+      else
+        data_valid_out  <= buff_tdc_valid(0);
+        data_out        <= buff_tdc_data(0);
+        -- count the leading tdc data
+        if(buff_tdc_data(0)(kPosHbdDataType'range)=kDatatypeTDCData)then
+          num_word      <= num_word + 1;
+        end if;
 
-  end generate;
+      end if;
+    end if;
+  end process;
 
   validOut  <= data_valid_out;
   dOut      <= data_out;


### PR DESCRIPTION
The updated is for add the function for count the generated data size.
The data size is counted in the "DelimiterInerter" of each channel, and the total data size is accumulated in the "MergerUnit".

The gen for loop of multi-channel from "odpblock/DelimiterInserter.vhd" to "lrtdc-impl/odpblock/ODPBlock.vhd".
The "DelimiterInerter.vhd" is used to "generate TDC data", "insert the heartbeat delimiter words", and "count the generated size" for a single channel.
Moreover, the "DelimiterInserter.vhd" use two-depths buffer to avoid that the delimiter word is conflicted with TDC data. 
Since the buffer only has two-depths, all data in the buffer must be clean in a heartbeat frame.

Beside the "gen_size accumulation", the "MergerUnit" merges the other "delimiter status".
The "flag" is merged by "or".
The "offset" is the offset of the last delimiter word,
but is the average offset for "HL-TDC".
The "userreg" is merged by "or".
The "gen_size" is accumulated.

**An issue needs to be noted.**
In the DelimiterInserter.vhd,
the delimiter word may be covered and lost by "daqOn". 